### PR TITLE
Add missing dependency for functional tests.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,8 @@
         "drush/drush": "^10.5",
         "symfony/yaml": "^4",
         "lullabot/drainpipe": "dev-main",
-        "drupal/coder": "^8.3"
+        "drupal/coder": "^8.3",
+        "friends-of-behat/mink-browserkit-driver": "^1.5"
     },
     "require-dev": {
         "composer/composer": "^2.0"


### PR DESCRIPTION
When running some functional Drupal tests, there are times when the following error happens:

```
Error: Class 'Behat\Mink\Driver\BrowserKitDriver' not found
```

This PR adds the missing dependency which produces the error.