### PR TITLE
#16: Remove unnecessary comma

### DIFF
--- a/config/nightwatch.conf.js
+++ b/config/nightwatch.conf.js
@@ -19,7 +19,7 @@ module.exports = {
   output_folder: 'test_result',
 
   // See https://nightwatchjs.org/guide/working-with-page-objects/
-  page_objects_path: [`${drupalCommandsPath}/page_objects`],,
+  page_objects_path: [`${drupalCommandsPath}/page_objects`],
 
   // See https://nightwatchjs.org/guide/extending-nightwatch/#writing-custom-commands
   custom_commands_path:  [`${a11yPath}/commands`, `${drupalCommandsPath}/commands`],


### PR DESCRIPTION
### Description

It fails with an error when trying to run nightwatch tests: 

```
 ddev task -t Taskfile.dev.yml test:nightwatch
```

```
 19/37 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓░░░░░░░░░░░░░░]  51%   SyntaxError: An error occurred while trying to start the Nightwatch Runner: Unexpected token ','
     page_objects_path: [`${drupalCommandsPath}/page_objects`],,
                                                               ^
   
   SyntaxError: Unexpected token ','
       at wrapSafe (internal/modules/cjs/loader.js:988:16)
       at Module._compile (internal/modules/cjs/loader.js:1036:27)
       at Object.Module._extensions..js (internal/modules/cjs/loader.js:1101:10)
       at Module.load (internal/modules/cjs/loader.js:937:32)
       at Function.external_module_.Module._load (/builds/indiecommerce/indiecommerce/.pnp.js:10839:14)
       at Module.require (internal/modules/cjs/loader.js:961:19)
       at require (internal/modules/cjs/helpers.js:92:18)
       at Object.<anonymous> (/builds/indiecommerce/indiecommerce/nightwatch.conf.js:1:25)
       at Module._compile (internal/modules/cjs/loader.js:1072:14)
       at Object.Module._extensions..js (internal/modules/cjs/loader.js:1101:10)
```

That's because the're a double ",," comma in config/nightwatch.conf.js 


### Testing steps


- [ ] Execute `ddev task -t Taskfile.dev.yml test:nightwatch`
- [ ] You shouldn't get double comma error
