### PR TITLE
Issue #18: Allow test failures to be surfaced as JUnit reports

### DIFF
--- a/bin/drainpipe-convert-to-junit-xml
+++ b/bin/drainpipe-convert-to-junit-xml
@@ -1,0 +1,59 @@
+#!/usr/bin/env php
+<?php
+
+function includeIfExists($file)
+{
+    if (file_exists($file)) {
+        return include $file;
+    }
+}
+
+if ((!$loader = includeIfExists(
+        __DIR__ . '/vendor/autoload.php'
+    )) && (!$loader = includeIfExists(__DIR__ . '/../autoload.php'))) {
+    die(
+        'You must set up the project dependencies, run the following commands:' . PHP_EOL .
+        'curl -sS https://getcomposer.org/installer | php' . PHP_EOL .
+        'php composer.phar install' . PHP_EOL
+    );
+}
+
+use Symfony\Component\Console\Application;
+use TijsVerkoyen\ConvertToJUnitXML\Command\ConvertNpmAuditCommand;
+use TijsVerkoyen\ConvertToJUnitXML\Command\ConvertSensiolabsSecurityCheckCommand;
+use TijsVerkoyen\ConvertToJUnitXML\Command\ConvertStandardJsCommand;
+use TijsVerkoyen\ConvertToJUnitXML\Command\ConvertStylelintCommand;
+use Lullabot\DrainpipeDev\ConvertToJUnitXML\Command\ConvertTwigLinterCommand;
+
+$application = new Application('Convert to JUnit XML');
+$application->add(
+    new \TijsVerkoyen\ConvertToJUnitXML\Command\ConvertBashGrepCommand(
+        new \TijsVerkoyen\ConvertToJUnitXML\Converters\Bash\Grep()
+    )
+);
+$application->add(
+    new ConvertNpmAuditCommand(
+        new \TijsVerkoyen\ConvertToJUnitXML\Converters\Npm\Audit()
+    )
+);
+$application->add(
+    new ConvertSensiolabsSecurityCheckCommand(
+        new \TijsVerkoyen\ConvertToJUnitXML\Converters\Sensiolabs\SecurityCheck()
+    )
+);
+$application->add(
+    new ConvertStandardJsCommand(
+        new \TijsVerkoyen\ConvertToJUnitXML\Converters\StandardJs\StandardJs()
+    )
+);
+$application->add(
+    new ConvertStylelintCommand(
+        new \TijsVerkoyen\ConvertToJUnitXML\Converters\Stylelint\Stylelint()
+    )
+);
+$application->add(
+    new ConvertTwigLinterCommand(
+        new \Lullabot\DrainpipeDev\ConvertToJUnitXML\Converters\TwigLinter\TwigLinter()
+    )
+);
+$application->run();

--- a/composer.json
+++ b/composer.json
@@ -24,12 +24,18 @@
         "symfony/yaml": "^4",
         "lullabot/drainpipe": "dev-main",
         "drupal/coder": "^8.3",
-        "friends-of-behat/mink-browserkit-driver": "^1.5"
+        "friends-of-behat/mink-browserkit-driver": "^1.5",
+        "tijsverkoyen/convert-to-junit-xml": "^1.9",
+        "mglaman/phpstan-junit": "^0.12.0",
+        "phpstan/phpstan-deprecation-rules": "^0.12.6"
     },
     "require-dev": {
         "composer/composer": "^2.0"
     },
-    "bin": ["bin/drainpipe-twig-linter"],
+    "bin": [
+        "bin/drainpipe-twig-linter",
+        "bin/drainpipe-convert-to-junit-xml"
+    ],
     "extra": {
         "class": [
             "\\Lullabot\\DrainpipeDev\\DevBinaryInstallerPlugin",

--- a/config/phpstan.neon
+++ b/config/phpstan.neon
@@ -1,5 +1,6 @@
 includes:
     - ../../../mglaman/phpstan-drupal/extension.neon
+    - ../../../phpstan/phpstan-deprecation-rules/rules.neon
 
 parameters:
     excludePaths:
@@ -9,3 +10,7 @@ parameters:
         - *settings.ddev.php
     # PHPStan Level 1
     level: 1
+
+services:
+	errorFormatter.junit:
+		class: PHPStan\Command\ErrorFormatter\JUnitErrorFormatter

--- a/src/ConvertToJUnitXML/Command/ConvertTwigLinterCommand.php
+++ b/src/ConvertToJUnitXML/Command/ConvertTwigLinterCommand.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Lullabot\DrainpipeDev\ConvertToJUnitXML\Command;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use TijsVerkoyen\ConvertToJUnitXML\Converters\ConverterInterface;
+
+class ConvertTwigLinterCommand extends Command
+{
+    /**
+     * @var ConverterInterface
+     */
+    private $converter;
+
+    public function __construct(ConverterInterface $converter)
+    {
+        $this->converter = $converter;
+
+        parent::__construct();
+    }
+
+    protected function configure()
+    {
+        $this
+            ->setName('convert:twig-linter')
+            ->setDescription(
+                'Convert the output of sserbin/twig-linter --format=json to JUnit XML.'
+            )
+            ->addArgument(
+                'input',
+                InputArgument::REQUIRED,
+                "The JSON to convert"
+            );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $jUnitReport = $this->converter->convert(
+            $input->getArgument('input')
+        );
+
+        $output->write($jUnitReport->__toString());
+
+        if ($jUnitReport->hasFailures()) {
+            return 1;
+        }
+
+        return 0;
+    }
+}

--- a/src/ConvertToJUnitXML/Converters/TwigLinter/TwigLinter.php
+++ b/src/ConvertToJUnitXML/Converters/TwigLinter/TwigLinter.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Lullabot\DrainpipeDev\ConvertToJUnitXML\Converters\TwigLinter;
+
+use TijsVerkoyen\ConvertToJUnitXML\Converters\ConverterInterface;
+use TijsVerkoyen\ConvertToJUnitXML\Converters\Exceptions\InvalidInputException;
+use TijsVerkoyen\ConvertToJUnitXML\JUnit\Failure;
+use TijsVerkoyen\ConvertToJUnitXML\JUnit\JUnit;
+use TijsVerkoyen\ConvertToJUnitXML\JUnit\TestCase;
+use TijsVerkoyen\ConvertToJUnitXML\JUnit\TestSuite;
+
+class TwigLinter implements ConverterInterface
+{
+    public function convert(string $input): JUnit
+    {
+        $data = json_decode($input);
+        print_r($input);
+
+        if ($data === null && json_last_error() !== JSON_ERROR_NONE) {
+            throw InvalidInputException::invalidJSON();
+        }
+
+        $files = [];
+        foreach ($data as $file) {
+            $files[$file->file][] = $file;
+        }
+
+        $jUnit = new JUnit();
+        $testSuite = new TestSuite('twig-linter');
+
+        foreach ($files as $file) {
+            $testCase = new TestCase(
+                sprintf(
+                    '%1$s',
+                    $file[0]->file
+                )
+            );
+
+            foreach ($file as $report) {
+                if (!$report->valid) {
+                    $testCase->addFailure(
+                        new Failure(
+                            'error',
+                            sprintf(
+                                '%1$s in %2$s on line: %3$s, column: %4$s.',
+                                $report->message,
+                                $report->file,
+                                $report->line,
+                                0
+                            ),
+                            sprintf(
+                                '%1$s in %2$s on line: %3$s, column: %4$s.',
+                                $report->message,
+                                $report->file,
+                                $report->line,
+                                0
+                            )
+                        )
+                    );
+                }
+            }
+            $testSuite->addTestCase($testCase);
+        }
+        $jUnit->addTestSuite($testSuite);
+
+        return $jUnit;
+    }
+}

--- a/tasks/test.yml
+++ b/tasks/test.yml
@@ -3,6 +3,7 @@ version: '3'
 # @todo allow these to be overridden or document them as required folder
 # structures. See also config/phpcs.xml and config/phpstan.neon
 vars:
+  TEST_OUTPUT_FORMAT: 'console'
   YAML_DIRS: 'web/**/*.yml'
   TWIG_DIRS: 'web/modules web/profiles web/themes'
   TEST_DIRS: 'web/modules/custom web/themes/custom web/sites'
@@ -23,12 +24,28 @@ tasks:
   security:
     desc: Runs security checks for composer packages and Drupal contrib
     cmds:
-      - ./vendor/bin/local-php-security-checker
+      - cmd: |
+          if [ "{{.TEST_OUTPUT_FORMAT}}" == "junit" ]; then
+            mkdir -p test_result
+            ./vendor/bin/local-php-security-checker --format=json > test_result/local-php-security-checker.json
+          fi
+        ignore_error: true
+      - |
+        if [ "{{.TEST_OUTPUT_FORMAT}}" == "junit" ]; then
+          RESULT=$(cat test_result/local-php-security-checker.json)
+          ./vendor/bin/drainpipe-convert-to-junit-xml convert:sensiolabs-security-check "$RESULT" > test_result/local-php-security-checker.xml
+          if [ "$RESULT" != "{}" ]; then
+            exit 1
+          fi
+        else
+          ./vendor/bin/local-php-security-checker
+        fi
+      # JUnit output blocked on https://github.com/drush-ops/drush/issues/4817
       - ./vendor/bin/drush pm:security
   lint:
     desc: Runs lint on composer, YAML, and Twig files
+    # @todo JUnit output
     cmds:
-      - echo {{.YAML_DIRS}}
       - composer validate
       - |
         DIRS_ARR=({{.YAML_DIRS}})
@@ -42,25 +59,44 @@ tasks:
         done
   config:
     desc: Verifies that exported config matches the config in Drupal
+    # @todo JUnit output
     cmds:
       - if [ $(./vendor/bin/drush config:status --format=string | wc -w) -gt 0 ]; then echo "Config export does not match"; drush config:status; exit 1; fi
   phpstan:
     dec: Runs PHPStan with mglaman/phpstan-drupal
     cmds:
-      - ./vendor/bin/phpstan analyse -c vendor/lullabot/drainpipe-dev/config/phpstan.neon {{.TEST_DIRS}}
+      - |
+        if [ "{{.TEST_OUTPUT_FORMAT}}" == "junit" ]; then
+          mkdir -p test_result
+          ./vendor/bin/phpstan analyse -c vendor/lullabot/drainpipe-dev/config/phpstan.neon --error-format=junit {{.TEST_DIRS}} > test_result/phpstan.xml
+        else
+          ./vendor/bin/phpstan analyse -c vendor/lullabot/drainpipe-dev/config/phpstan.neon {{.TEST_DIRS}}
+        fi
   phpunit:
     desc: Runs PHPUnit
     cmds:
       - |
         {{ .FUNC_ENSURE_DIRS }}
-      - ./vendor/bin/phpunit {{.TEST_DIRS}}
+      - |
+        if [ "{{.TEST_OUTPUT_FORMAT}}" == "junit" ]; then
+          mkdir -p test_result
+          ./vendor/bin/phpunit --log-junit test_result/phpunit.xml {{.TEST_DIRS}}
+        else
+          ./vendor/bin/phpunit {{.TEST_DIRS}}
+        fi
   phpcs:
     desc: Runs PHPCS with Drupal Coding Standards
     cmds:
       - |
         {{ .FUNC_ENSURE_DIRS }}
       - ./vendor/bin/phpcs --config-set installed_paths vendor/drupal/coder/coder_sniffer
-      - ./vendor/bin/phpcs --standard=vendor/lullabot/drainpipe-dev/config/phpcs.xml {{.TEST_DIRS}}
+      - |
+        if [ "{{.TEST_OUTPUT_FORMAT}}" == "junit" ]; then
+          mkdir -p test_result
+          ./vendor/bin/phpcs --report=junit -q --standard=vendor/lullabot/drainpipe-dev/config/phpcs.xml {{.TEST_DIRS}} > test_result/phpcs.xml
+        else
+          ./vendor/bin/phpcs --standard=vendor/lullabot/drainpipe-dev/config/phpcs.xml {{.TEST_DIRS}}
+        fi
   autofix:
     desc: Runs PHPCBF with Drupal Coding Standards to fix PHPCS violations
     cmds:


### PR DESCRIPTION
## Testing Instructions
- [ ] In an existing project run
  ```
  ddev composer config repositories.lullabot/drainpipe-dev git https://github.com/lullabot/drainpipe-dev.git
  ddev composer require lullabot/drainpipe-dev:dev-justafish/18/test-results-junit
  ```
- [ ] Run `ddev task -t Taskfile.dev.yml TEST_OUTPUT_FORMAT=junit test`
- [ ] Verify the `test_result` directory gets populated with JUnit files