### PR TITLE
Support overriding phpcs.xml

### DIFF
--- a/.github/workflows/test-static-tests.yml
+++ b/.github/workflows/test-static-tests.yml
@@ -36,3 +36,6 @@ jobs:
         run: |
           cd ../drupal
           ./vendor/bin/task -t Taskfile.dev.yml test:static
+          # Test overriding phpcs.xml
+          cp -v ./vendor/bin/lullabot/drainpipe-dev/config/phpcs.xml .
+          ./vendor/bin/task -t Taskfile.dev.yml test:phpcs

--- a/config/phpcs.xml
+++ b/config/phpcs.xml
@@ -8,13 +8,19 @@
     <arg value="p"/>
 
     <!-- Include common Drupal standards. -->
-    <rule ref="Drupal"/>
-    <rule ref="DrupalPractice"/>
+    <!-- When overriding, update the relative path to point to the vendor directory. -->
+    <!-- Note that relative paths must begin with a dot, such as ./vendor/... -->
+    <rule ref="../../drupal/coder/coder_sniffer/Drupal/ruleset.xml"/>
+    <rule ref="../../drupal/coder/coder_sniffer/DrupalPractice/ruleset.xml"/>
 
     <!-- Apply same exclusions for T function applied by core. -->
     <rule ref="Drupal.Semantics.FunctionT">
         <exclude name="Drupal.Semantics.FunctionT.NotLiteralString"/>
     </rule>
+
+    <file>web/modules/custom</file>
+    <file>web/themes/custom</file>
+    <file>web/sites</file>
 
     <!-- Exclude JS and CSS, this is covered by yarn scripts -->
     <exclude-pattern>**/*.js</exclude-pattern>

--- a/tasks/test.yml
+++ b/tasks/test.yml
@@ -85,14 +85,18 @@ tasks:
         fi
   phpcs:
     desc: Runs PHPCS with Drupal Coding Standards
+    summary: |
+      Check your code against Drupal's coding standards. To override the default
+      ruleset, copy vendor/lullabot/drainpipe-dev/config/phpcs.xml to phpcs.xml
+      in the root of your project and edit as needed.
     cmds:
       - |
-        {{ .FUNC_ENSURE_DIRS }}
-      - ./vendor/bin/phpcs --config-set installed_paths vendor/drupal/coder/coder_sniffer
-      - |
+        if [ ! -f phpcs.xml ]; then
+          STANDARD="--standard=vendor/lullabot/drainpipe-dev/config/phpcs.xml"
+        fi
         if [ "{{.format}}" == "junit" ]; then
           mkdir -p test_result
-          ./vendor/bin/phpcs --report=junit -q --standard=vendor/lullabot/drainpipe-dev/config/phpcs.xml {{.TEST_DIRS}} > test_result/phpcs.xml
+          ./vendor/bin/phpcs --report=junit -q $STANDARD {{.TEST_DIRS}} > test_result/phpcs.xml
         else
           ./vendor/bin/phpcs --standard=vendor/lullabot/drainpipe-dev/config/phpcs.xml {{.TEST_DIRS}}
         fi


### PR DESCRIPTION
This PR:

- Switches from requiring the global installed paths to be set, to instead using relative file paths in the configuration file.
- Respects phpcs.xml if it's in the root of the repository. Otherwise, the default one is used.

I thought about making this an automatic copy like `Taskfile.yml`, however I think reconciling differences is rare, if ever.