### PR TITLE
Check for yarn

### DIFF
--- a/src/DevScaffoldInstallerPlugin.php
+++ b/src/DevScaffoldInstallerPlugin.php
@@ -257,10 +257,6 @@ class DevScaffoldInstallerPlugin implements PluginInterface, EventSubscriberInte
             $this->installScaffoldFile('example.nightwatch.js', 'test/nightwatch/example.nightwatch.js');
         }
 
-        if (!(new ExecutableFinder())->find('yarn')) {
-            throw new \RuntimeException('yarn could not be found. Install it with npm -g install yarn.');
-        }
-
         // Create a new yarn project if package.json doesn't exist
         if (!file_exists('./package.json')) {
             $yarn = new Process(['yarn', 'set', 'version', 'berry']);
@@ -309,6 +305,10 @@ class DevScaffoldInstallerPlugin implements PluginInterface, EventSubscriberInte
 
         if (!empty($needToInstall)) {
             if (file_exists('yarn.lock')) {
+                if (!(new ExecutableFinder())->find('yarn')) {
+                    throw new \RuntimeException('yarn could not be found. Install it with npm -g install yarn.');
+                }
+
                 $this->userCommands[] = sprintf('yarn add %s --dev', implode(' ', array_values($dependencies)));
                 if ($this->environment === 'ddev') {
                     $this->userCommands[] = 'ddev exec yarn';

--- a/src/DevScaffoldInstallerPlugin.php
+++ b/src/DevScaffoldInstallerPlugin.php
@@ -280,7 +280,7 @@ class DevScaffoldInstallerPlugin implements PluginInterface, EventSubscriberInte
                 }
             });
             // Override the package.json name field as yarn will have used the
-            //folder name, which is just "html" in DDEV.
+            // folder name, which is just "html" in DDEV.
             if ($this->environment === 'ddev' && !empty(getenv('DDEV_PROJECT'))) {
                 $packageJsonContents = file_get_contents('./package.json');
                 $packageJsonContents = str_replace('html', getenv('DDEV_PROJECT'), $packageJsonContents);

--- a/src/DevScaffoldInstallerPlugin.php
+++ b/src/DevScaffoldInstallerPlugin.php
@@ -12,6 +12,7 @@ use Composer\Plugin\PluginInterface;
 use Composer\Script\Event;
 use Composer\Script\ScriptEvents;
 use Composer\Util\Filesystem;
+use Symfony\Component\Process\ExecutableFinder;
 use Symfony\Component\Yaml\Yaml;
 use Symfony\Component\Process\Process;
 
@@ -254,6 +255,10 @@ class DevScaffoldInstallerPlugin implements PluginInterface, EventSubscriberInte
         if (!file_exists('./test/nightwatch')) {
             $fs->ensureDirectoryExists('./test/nightwatch');
             $this->installScaffoldFile('example.nightwatch.js', 'test/nightwatch/example.nightwatch.js');
+        }
+
+        if (!(new ExecutableFinder())->find('yarn')) {
+            throw new \RuntimeException('yarn could not be found. Install it with npm -g install yarn.');
         }
 
         // Create a new yarn project if package.json doesn't exist


### PR DESCRIPTION
When switching between node versions, it's easy to miss installing yarn for a given version. As is, we fail with a "package.json could not be created" message, which doesn't tell you why or how to fix it.

Two followup questions:

1. Should we be logging errors with `writeError` instead of `write`, so it goes to stderr?
2. Should we be using `mustRun` instead of `run` so failures aren't silent?