### PR TITLE
Upgrade PHPStan

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,6 @@
         "drupal/coder": "^8.3",
         "friends-of-behat/mink-browserkit-driver": "^1.5",
         "tijsverkoyen/convert-to-junit-xml": "^1.9",
-        "mglaman/phpstan-junit": "^0.12.0",
         "phpstan/phpstan-deprecation-rules": "^1.0.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "mockery/mockery": "^1.4",
         "behat/mink": "^1.8",
         "symfony/phpunit-bridge": "^5.3",
-        "mglaman/phpstan-drupal": "^0.12.10",
+        "mglaman/phpstan-drupal": "^1.0.3",
         "drush/drush": "^10.5",
         "symfony/yaml": "^4",
         "lullabot/drainpipe": "dev-main",
@@ -27,7 +27,7 @@
         "friends-of-behat/mink-browserkit-driver": "^1.5",
         "tijsverkoyen/convert-to-junit-xml": "^1.9",
         "mglaman/phpstan-junit": "^0.12.0",
-        "phpstan/phpstan-deprecation-rules": "^0.12.6"
+        "phpstan/phpstan-deprecation-rules": "^1.0.0"
     },
     "require-dev": {
         "composer/composer": "^2.0"

--- a/config/phpstan.neon
+++ b/config/phpstan.neon
@@ -11,6 +11,3 @@ parameters:
     # PHPStan Level 1
     level: 1
 
-services:
-	errorFormatter.junit:
-		class: PHPStan\Command\ErrorFormatter\JUnitErrorFormatter


### PR DESCRIPTION
Also remove mglaman/phpstan-junit as this is now built in to phpstan

```
secretproject on  main [$!] via ⬢ v15.11.0 via 🐘 v7.4.16 took 11s 
❯ ddev composer require lullabot/drainpipe-dev:dev-justafish/upgrade-phpstan -W --dev
./composer.json has been updated
Running composer update lullabot/drainpipe-dev --with-all-dependencies
Gathering patches for root package.
Loading composer repositories with package information
Updating dependencies                                 
Lock file operations: 0 installs, 5 updates, 1 removal
  - Removing mglaman/phpstan-junit (0.12)
  - Upgrading lullabot/drainpipe-dev (dev-main 5dde394 => dev-justafish/upgrade-phpstan 774dc07)
  - Upgrading mglaman/phpstan-drupal (0.12.15 => 1.0.3)
  - Upgrading phpstan/phpstan (0.12.99 => 1.1.2)
  - Upgrading phpstan/phpstan-deprecation-rules (0.12.6 => 1.0.0)
  - Upgrading sebastian/exporter (4.0.3 => 4.0.4)
Writing lock file
Installing dependencies from lock file (including require-dev)
Package operations: 0 installs, 5 updates, 1 removal
  - Downloading phpstan/phpstan (1.1.2)
  - Downloading phpstan/phpstan-deprecation-rules (1.0.0)
  - Downloading mglaman/phpstan-drupal (1.0.3)
  - Downloading lullabot/drainpipe-dev (dev-justafish/upgrade-phpstan 774dc07)
  - Downloading sebastian/exporter (4.0.4)
  - Removing mglaman/phpstan-junit (0.12)
Gathering patches for root package.
Gathering patches for dependencies. This might take a minute.
  - Upgrading phpstan/phpstan (0.12.99 => 1.1.2): Extracting archive
  - Upgrading phpstan/phpstan-deprecation-rules (0.12.6 => 1.0.0): Extracting archive
  - Upgrading mglaman/phpstan-drupal (0.12.15 => 1.0.3): Extracting archive
  - Upgrading lullabot/drainpipe-dev (dev-main 5dde394 => dev-justafish/upgrade-phpstan 774dc07): Extracting archive
  - Upgrading sebastian/exporter (4.0.3 => 4.0.4): Extracting archive
Package doctrine/reflection is abandoned, you should avoid using it. Use roave/better-reflection instead.
Package webmozart/path-util is abandoned, you should avoid using it. Use symfony/filesystem instead.
Generating autoload files
composer/package-versions-deprecated: Generating version class...
composer/package-versions-deprecated: ...done generating version class
82 packages you are using are looking for funding.
Use the `composer fund` command to find out more!
Using cached version of task v3.9.0 (cad72446d2b939ec611fea14c48f7ce28713c68cc902701fb4f1c2b12fe1fd1c)
task v3.9.0 (cad72446d2b939ec611fea14c48f7ce28713c68cc902701fb4f1c2b12fe1fd1c) already exists in bin-dir, not overwriting.
local-php-security-checker v1.0.0 (e5b12488ca78bc07c149e9352278bf10667b88a8461caac10154f9a6f5476369) already exists in bin-dir, not overwriting.
local-php-security-checker v1.0.0 (e5b12488ca78bc07c149e9352278bf10667b88a8461caac10154f9a6f5476369) already exists in bin-dir, not overwriting.
.ddev/docker-compose.selenium.yaml has either been customized or requires review.
Compare .ddev/docker-compose.selenium.yaml with /var/www/html/vendor/lullabot/drainpipe-dev/scaffold/docker-compose.selenium.yaml and update as needed.
web/sites/firefox/settings.php has either been customized or requires review.
Compare web/sites/firefox/settings.php with /var/www/html/vendor/lullabot/drainpipe-dev/scaffold/firefox.settings.php and update as needed.
web/sites/chrome/settings.php has either been customized or requires review.
Compare web/sites/chrome/settings.php with /var/www/html/vendor/lullabot/drainpipe-dev/scaffold/chrome.settings.php and update as needed.
web/sites/sites.php has either been customized or requires review.
Compare web/sites/sites.php with /var/www/html/vendor/lullabot/drainpipe-dev/scaffold/sites.php and update as needed.

secretproject on  main [$!] via ⬢ v15.11.0 via 🐘 v7.4.16 took 16s 
❯ ddev task -t Taskfile.dev.yml test:phpstan
task: [test:phpstan] if [ "" == "junit" ]; then
  mkdir -p test_result
  ./vendor/bin/phpstan analyse -c vendor/lullabot/drainpipe-dev/config/phpstan.neon --error-format=junit web/modules/custom web/themes/custom web/sites > test_result/phpstan.xml
else
  ./vendor/bin/phpstan analyse -c vendor/lullabot/drainpipe-dev/config/phpstan.neon web/modules/custom web/themes/custom web/sites
fi

 98/98 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%

```