### PR TITLE
Change Twig linter bin to be compatible with Drupal 9.3

### DIFF
--- a/bin/drainpipe-twig-linter
+++ b/bin/drainpipe-twig-linter
@@ -16,6 +16,7 @@ else {
 }
 
 use Drupal\Core\Datetime\DateFormatterInterface;
+use Drupal\Core\File\FileUrlGenerator;
 use Drupal\Core\Render\RendererInterface;
 use Drupal\Core\Routing\UrlGeneratorInterface;
 use Drupal\Core\Theme\ThemeManagerInterface;
@@ -33,10 +34,9 @@ $renderer = Mockery::mock(RendererInterface::class);
 $urlGenerator = Mockery::mock(UrlGeneratorInterface::class);
 $themeManager = Mockery::mock(ThemeManagerInterface::class);
 $dateFormatter = Mockery::mock(DateFormatterInterface::class);
+$fileUrlGenerator = Mockery::mock(FileUrlGenerator::class);
 
-
-$twig->addExtension(new TwigExtension($renderer, $urlGenerator, $themeManager, $dateFormatter));
-
+$twig->addExtension(new TwigExtension($renderer, $urlGenerator, $themeManager, $dateFormatter, $fileUrlGenerator));
 
 $lintCommand = new LintCommand($twig);
 


### PR DESCRIPTION
When creating the TwigExtension object, it is required to pass the file url generator service to the constructor.

Related: https://www.drupal.org/node/2940031