### PR TITLE
Make PHPStan configurable per project

### DIFF
--- a/config/phpstan.neon
+++ b/config/phpstan.neon
@@ -1,6 +1,7 @@
 includes:
     - ../../../mglaman/phpstan-drupal/extension.neon
     - ../../../phpstan/phpstan-deprecation-rules/rules.neon
+    - ../../../../phpstan.neon
 
 parameters:
     excludePaths:

--- a/scaffold/phpstan.neon
+++ b/scaffold/phpstan.neon
@@ -1,0 +1,7 @@
+parameters:
+    ignoreErrors:
+        -
+            message: '#Variable \$(app_root|site_path) might not be defined\.#'
+            paths:
+                - *sites/default/settings.php
+                - *sites/sites.php

--- a/scaffold/phpstan.neon
+++ b/scaffold/phpstan.neon
@@ -1,7 +1,1 @@
 parameters:
-    ignoreErrors:
-        -
-            message: '#Variable \$(app_root|site_path) might not be defined\.#'
-            paths:
-                - *sites/default/settings.php
-                - *sites/sites.php

--- a/src/DevScaffoldInstallerPlugin.php
+++ b/src/DevScaffoldInstallerPlugin.php
@@ -90,6 +90,7 @@ class DevScaffoldInstallerPlugin implements PluginInterface, EventSubscriberInte
         $this->installDdevSeleniumConfig();
         $this->installNightwatchConfig();
         $this->installPhpCsConfig();
+        $this->installPhpStanConfig();
         $this->printUserCommands();
     }
 
@@ -103,6 +104,7 @@ class DevScaffoldInstallerPlugin implements PluginInterface, EventSubscriberInte
         $this->installDdevSeleniumConfig();
         $this->installNightwatchConfig();
         $this->installPhpCsConfig();
+        $this->installPhpStanConfig();
         $this->printUserCommands();
     }
 
@@ -302,6 +304,13 @@ class DevScaffoldInstallerPlugin implements PluginInterface, EventSubscriberInte
     {
         if (!file_exists('./phpcs.xml')) {
             $this->installScaffoldFile('phpcs.xml', 'phpcs.xml');
+        }
+    }
+
+    private function installPhpStanConfig(): void
+    {
+        if (!file_exists('./phpstan.neon')) {
+            $this->installScaffoldFile('phpstan.neon', 'phpstan.neon');
         }
     }
 }


### PR DESCRIPTION
How does this approach work for y'all? Would rather not have to scaffold the empty `phpstan.neon` file, but PHPStan's config doesn't support "optional" includes. Could maybe submit that upstream though, like @justafish did for Task.