### PR TITLE
Fix shell parsing with ddev in install docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ environments.
   or if using DDEV:
   ```
   ddev composer config extra.drupal-scaffold.gitignore true
-  ddev composer "config --json extra.drupal-scaffold.allowed-packages '[\"lullabot/drainpipe-dev\"]'"
+  ddev composer config --json extra.drupal-scaffold.allowed-packages \[\"lullabot/drainpipe-dev\"]
   ```
 - Ensure your project's `composer.json` now contains the following:
   ```


### PR DESCRIPTION
With the current command:

```
ddev composer config --json extra.drupal-scaffold.allowed-packages '[\"lullabot/drainpipe-dev\"]'


  [Seld\JsonLint\ParsingException]
  "" does not contain valid JSON
  Parse error on line 1:
  [\"lullabot/drainpipe
  ^
  Expected one of: 'STRING', 'NUMBER', 'NULL', 'TRUE', 'FALSE', '{', '[', ']'


config [-g|--global] [-e|--editor] [-a|--auth] [--unset] [-l|--list] [-f|--file FILE] [--absolute] [-j|--json] [-m|--merge] [--append] [--source] [--] [<setting-key>] [<setting-value>]...

composer [config --json extra.drupal-scaffold.allowed-packages [\"lullabot/drainpipe-dev\"]] failed, composer command failed: exit status 1. stderr=
```

This fixes it for me in both zsh and bash.