### PR TITLE
Issue #63: Create files private directory for chrome and firefox.

### DIFF
--- a/tasks/test.yml
+++ b/tasks/test.yml
@@ -257,10 +257,12 @@ tasks:
     desc: "Runs the site installer for the Firefox container"
     cmds:
       - ./vendor/bin/drush --uri=https://drupal_firefox --yes site:install --existing-config
+      - mkdir -p /var/www/html/web/sites/firefox/files/private
   nightwatch:siteinstall:chrome:
     desc: "Runs the site installer for the Chrome container"
     cmds:
       - ./vendor/bin/drush --uri=https://drupal_chrome --yes site:install --existing-config
+      - mkdir -p /var/www/html/web/sites/chrome/files/private
   nightwatch:siteinstall:
     desc: "Runs the site installer for the Firefox and Chrome containers"
     deps: [nightwatch:siteinstall:firefox, nightwatch:siteinstall:chrome]


### PR DESCRIPTION
Fixes #63

This PR should create the private files directory for the firefox and chrome "multi-sites", so that automated tests can pass when the drupal status report doesn't have an error about the private dir.