### PR TITLE
Fix PHPCS sniff violations on scaffolded sites.php

### DIFF
--- a/scaffold/nightwatch/sites.php
+++ b/scaffold/nightwatch/sites.php
@@ -1,5 +1,7 @@
 <?php
 
+// phpcs:ignoreFile
+
 /**
  * @file
  * Multi-site configuration.

--- a/scaffold/nightwatch/sites.php
+++ b/scaffold/nightwatch/sites.php
@@ -1,13 +1,13 @@
 <?php
 
-// phpcs:ignoreFile
-
 /**
  * @file
  * Multi-site configuration.
  *
  * Allows separate installs for Chrome and Firefox Nightwatch testing.
  */
+
+declare(strict_types=1);
 
 if (getenv('IS_DDEV_PROJECT') == 'true') {
   $sites['drupal_chrome'] = 'chrome';


### PR DESCRIPTION
Otherwise PHPCS complains e.g., about missing strict types in `sites.php`.