### PR TITLE
Ignore node_modules folder when executing  phpstan tests

### DIFF
--- a/config/phpstan.neon
+++ b/config/phpstan.neon
@@ -8,6 +8,7 @@ parameters:
         - *default.settings.php
         - *sites/*/files/*
         - *settings.ddev.php
+        - */node_modules/*
     # PHPStan Level 1
     level: 1
 


### PR DESCRIPTION
This PR is also related to this issue #67 .
 the phpstan is looking into the node_modules folder and finding this file : `...w/html/web/themes/custom/4k/node_modules/flatted/php/flatted.php`
 
<img width="744" alt="Screenshot 2022-12-01 at 12 26 48 PM" src="https://user-images.githubusercontent.com/2217827/205144205-55b0b05b-8217-4c24-8823-f90e97eeca08.png">

So similar propused solution like in the other PR , adding a extra exception but this time, ino the phpstan.neon
``` - */node_modules/* ```
