### PR TITLE
Remove includeFunctionRule which breaks TwigJS

### DIFF
--- a/scaffold/.twig-cs-fixer.dist.php
+++ b/scaffold/.twig-cs-fixer.dist.php
@@ -32,6 +32,9 @@ $ruleset = new TwigCsFixer\Ruleset\Ruleset();
 // default standard.
 $ruleset->addStandard(new TwigCsFixer\Standard\TwigCsFixer());
 
+// Remove the IncludeFunctionRule which breaks TwigJS.
+$ruleset->removeRule(TwigCsFixer\Rules\Function\includeFunctionRule::class);
+
 $config = new TwigCsFixer\Config\Config();
 $config->setRuleset($ruleset);
 $config->addTwigExtension(new TwigExtension($renderer, $urlGenerator, $themeManager, $dateFormatter, $fileUrlGenerator));


### PR DESCRIPTION
The TwigCSFixer adds a fix which changes include tags to include functions. This works great in PHP but breaks TwigJS and subsequently, Storybook.

This PR excludes this rule per https://github.com/VincentLanglet/Twig-CS-Fixer/blob/main/docs/configuration.md

See https://github.com/Lullabot/lullabot.com-d8/issues/3957