### PR TITLE
Ignore phpcs for settings.local.php

### DIFF
--- a/scaffold/phpcs.xml.dist
+++ b/scaffold/phpcs.xml.dist
@@ -34,6 +34,7 @@
     <exclude-pattern>*/default.settings.php</exclude-pattern>
     <exclude-pattern>*/sites/*/files/*</exclude-pattern>
     <exclude-pattern>*/settings.ddev.php</exclude-pattern>
+    <exclude-pattern>*/settings.local.php</exclude-pattern>
     <exclude-pattern>*/sites/simpletest/*</exclude-pattern>
     <exclude-pattern>*/node_modules/*</exclude-pattern>
 </ruleset>


### PR DESCRIPTION
It's common to have one or more `settings.local.php` files defined in your Drupal project. These are typically `.gitignore`'d and are completely and totally just for local development. They never need to be checked with `phpcs` and will often turn up common phpcs errors like the following for an unused variable:

```
[test:phpcs] FILE: /var/www/html/web/sites/default/settings.local.php
[test:phpcs] ----------------------------------------------------------------------
[test:phpcs] FOUND 0 ERRORS AND 1 WARNING AFFECTING 1 LINE
[test:phpcs] ----------------------------------------------------------------------
[test:phpcs]  14 | WARNING | Unused variable $theme_dev_mode.
[test:phpcs] ----------------------------------------------------------------------
```

This change ignores all `settings.local.php` files when running `phpcs`.

